### PR TITLE
Create CHANGELOG.md when missing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 This project follows [Semantic Versioning 2.0.0](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Create CHANGELOG.md when missing
+
 ## [0.0.4] - 2020-06-24
 ### Added
 - Support for multiple major versions in a single file

--- a/lib/src/app/change_app.dart
+++ b/lib/src/app/change_app.dart
@@ -24,6 +24,6 @@ class ChangeApp {
   Future<File> _write(Changelog changelog) =>
       file.writeAsString(changelog.dump());
 
-  Future<Changelog> _read() async =>
-      Changelog.fromMarkdown(Document().parseLines(await file.readAsLines()));
+  Future<Changelog> _read() async => Changelog.fromMarkdown(Document()
+      .parseLines(await file.create().then((file) => file.readAsLines())));
 }

--- a/test/app_functional_test.dart
+++ b/test/app_functional_test.dart
@@ -18,6 +18,17 @@ void main() {
 
   tearDown(() async {});
 
+  test('Can add to empty', () async {
+    final changelog = '${temp.path}/CHANGELOG.md';
+
+    expect(
+        await app
+            .run(['added', 'Programmatically added change', '-p', changelog]),
+        0);
+    expect(File(changelog).readAsStringSync(),
+        File('test/example/step0.md').readAsStringSync());
+  });
+
   test('Can add changes', () async {
     final changelog = '${temp.path}/CHANGELOG.md';
     await File('test/example/step1.md').copy(changelog);

--- a/test/example/step0.md
+++ b/test/example/step0.md
@@ -1,0 +1,3 @@
+## Unreleased
+### Added
+- Programmatically added change


### PR DESCRIPTION
Initial case in any project, simplifies using the tool.