### PR TITLE
Add command 'print' to output a released version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 This project follows [Semantic Versioning 2.0.0](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- New command 'print' to output a released version
+
 ## [0.0.5] - 2020-07-05
 ### Added
 - Create CHANGELOG.md when missing

--- a/README.md
+++ b/README.md
@@ -72,3 +72,33 @@ CHANGELOG after:
 
 [Unreleased]: https://github.com/example/project/compare/0.1.0...HEAD
 ```
+
+### Printing a released version
+Suitable for use in e-mails or Git commit messages.
+
+#### Example
+By running this command for the example CHANGELOG
+
+```shell
+change print 0.1.0
+```
+
+It outputs:
+```shell
+### Added
+- New *cool* feature
+
+### Changed
+- Renamed foo to [bar](https://example.com/bar)
+```
+
+It will print the diff link as well, when a previous release exists.
+
+#### How to use as a Git commit message
+You can create a signed-off release commit including changes for a specific release like this:
+
+```shell script
+git commit -m "Release version 0.1.0
+
+$(change print 0.1.0)" --signoff
+```

--- a/lib/src/app/change_app.dart
+++ b/lib/src/app/change_app.dart
@@ -15,6 +15,11 @@ class ChangeApp {
     await _write(changelog);
   }
 
+  Future<Release> get(String version) async {
+    final changelog = await _read();
+    return changelog.releases.firstWhere((element) => element.version == version);
+  }
+
   Future<void> release(String version, String date, String diff) async {
     final changelog = await _read();
     changelog.release(version, date, link: diff.isNotEmpty ? diff : null);

--- a/test/app_functional_test.dart
+++ b/test/app_functional_test.dart
@@ -7,7 +7,7 @@ import 'package:test/test.dart';
 
 void main() {
   Directory temp;
-  Console console;
+  MockConsole console;
   CommandRunner<int> app;
 
   setUp(() async {
@@ -67,6 +67,33 @@ void main() {
         0);
     expect(File(changelog).readAsStringSync(),
         File('test/example/step3.md').readAsStringSync());
+  });
+
+  test('Can print released versions', () async {
+    final changelog = 'test/example/step3.md';
+
+    expect(await app.run(['print', '-p', changelog]), 1,
+        reason: 'Missing version');
+    expect(console.errors.last, 'Please specify released version to print.');
+    expect(await app.run(['print', '2.0.0', '-p', changelog]), 1,
+        reason: 'Unknown version');
+    expect(console.errors.last, 'Version \'2.0.0\' not found!');
+
+    expect(await app.run(['print', '1.0.0', '-p', changelog]), 0);
+    expect(console.logs.last, '''
+### Added
+- Initial version of the example''');
+    expect(await app.run(['print', '1.1.0', '-p', changelog]), 0);
+    expect(console.logs.last, '''
+### Changed
+- Change #1
+- Change #2
+- Programmatically added change
+
+### Deprecated
+- Programmatically added deprecation
+
+[1.1.0]: https://github.com/example/project/compare/1.0.0...1.1.0''');
   });
 }
 


### PR DESCRIPTION
Useful when creating a release commit or e-mail where the recently released changes should be included.