### PR TITLE
Update dependency `intl` to `>=0.17.0 <1.0.0`

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -15,7 +15,7 @@ dependencies:
   markdown: ^6.0.0
   marker: ^0.4.0
   pub_semver: ^2.1.1
-  intl: ^0.17.0
+  intl: '>=0.17.0 <1.0.0'
 
 dev_dependencies:
   lints: ^2.0.1


### PR DESCRIPTION
Getting the following error when I try to bump `intl` to `0.18.0` in my project ([PR](https://github.com/zeshuaro/appainter/pull/544#issuecomment-1365841301) for reference):

```
Because change 0.5.0 depends on intl ^0.17.0 and no versions of change match >0.5.0 <0.6.0, change ^0.5.0 requires intl ^0.17.0.
And because cider 0.1.3 depends on change ^0.5.0, cider 0.1.3 requires intl ^0.17.0.
So, because appainter depends on both intl 0.18.0 and cider 0.1.3, version solving failed.
```

From Pub [docs](https://pub.dev/packages/pub_semver) and [this](https://github.com/dart-lang/pub/issues/3747) related issue, they explain why Pub is unable to resolve `intl` to the latest version `0.18.0`:

> There is a notion of compatibility between pre-1.0.0 versions. Semver deems all pre-1.0.0 versions to be incompatible. This means that the only way to ensure compatibility when depending on a pre-1.0.0 package is to pin the dependency to an exact version. Pinned version constraints prevent automatic patch and pre-release updates. To avoid this situation, pub defines the "next breaking" version as the version which increments the major version if it's greater than zero, and the minor version otherwise, resets subsequent digits to zero, and strips any pre-release or build suffix. For example, here are some versions along with their next breaking ones:
> 
> 0.0.3 -> 0.1.0 0.7.2-alpha -> 0.8.0 1.2.3 -> 2.0.0
> 
> To make use of this, pub defines a "^" operator which yields a version constraint greater than or equal to a given version, but less than its next breaking one.

It's probably safe to assume `intl` is not rolling out breaking changes until they release `1.0.0`, as the recent release also doesn't contain any breaking changes. So this PR relaxes the constraints of `intl` to `>=0.17.0 <1.0.0`. 

After releasing a new version of `change`, I think `cider` would also need to be updated to use the latest version of `change` to actually resolve the problem I reported at the top.