### PR TITLE
Keep freetext in the beginning of a release.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 This project follows [Semantic Versioning 2.0.0](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+### Added
+- keep freetext directly under release headings
+
 ## [0.6.0] - 2023-02-14
 ### Added
 - You may pass an instance of markdown `Document` to the `parseChangelog()` to have fine-grained control over parsing, e.g. whether to encode HTML entities
@@ -111,6 +115,7 @@ This project follows [Semantic Versioning 2.0.0](https://semver.org/spec/v2.0.0.
 - Parsing from markdown
 - Writing to markdown
 
+[Unreleased]: https://github.com/f3ath/change/compare/0.6.0...HEAD
 [0.6.0]: https://github.com/f3ath/change/compare/0.5.0...0.6.0
 [0.5.0]: https://github.com/f3ath/change/compare/0.4.0...0.5.0
 [0.4.0]: https://github.com/f3ath/change/compare/0.3.1...0.4.0

--- a/lib/src/printer.dart
+++ b/lib/src/printer.dart
@@ -46,6 +46,7 @@ Iterable<Element> _unreleased(Section section) sync* {
     header.add(_link(sectionLink, [text]));
   }
   yield Element('h2', header);
+  yield Element('span', section.header);
   yield* _changes(section);
 }
 
@@ -63,6 +64,7 @@ Iterable<Element> _release(Release release) sync* {
     header.add(Text(' [YANKED]'));
   }
   yield Element('h2', header);
+  yield Element('span', release.header);
   yield* _changes(release);
 }
 

--- a/lib/src/release.dart
+++ b/lib/src/release.dart
@@ -4,6 +4,10 @@ import 'package:pub_semver/pub_semver.dart';
 class Release extends Section implements Comparable<Release> {
   Release(this.version, this.date, {this.isYanked = false});
 
+  Release.fromSection(this.version, this.date, Section section,
+      {this.isYanked = false})
+      : super.copy(section);
+
   /// Release version.
   Version version;
 

--- a/lib/src/section.dart
+++ b/lib/src/section.dart
@@ -1,11 +1,19 @@
 import 'package:change/src/change.dart';
+import 'package:markdown/markdown.dart' show Node;
 
 /// A release or the unreleased section
 class Section {
+  Section.copy(Section other)
+      : _changes = other._changes,
+        link = other.link,
+        _header = other.header;
+
   final _changes = <Change>[];
 
   /// Section link. Usually, the diff
   String link = '';
+
+  List<Node> _header = [];
 
   /// Changes in the change set, optionally filtered by [type]
   Iterable<Change> changes({String? type}) {
@@ -23,6 +31,16 @@ class Section {
     _changes.addAll(changes);
   }
 
+  /// Set header nodes
+  void set setHeader(List<Node> header) {
+    _header = header;
+  }
+
+  /// Get header nodes
+  List<Node> get header {
+    return _header;
+  }
+
   /// True if the section contains not changes
   bool get isEmpty => _changes.isEmpty;
 
@@ -33,5 +51,6 @@ class Section {
   void clear() {
     _changes.clear();
     link = '';
+    setHeader = [];
   }
 }


### PR DESCRIPTION
fixes #13 partially, a pr for cider will follow

There are a few things which are debatable (i.e. do we really need getter and setter for `_headers`?, the thought behind htas was that it feels a bit dirty to simply keep a list of elements, and maybe the implementation to keep the headers might change, but I am not sure if it would not be better to remove the getter/setter and readd them if needed (KISS?)).

One could look at `Section.copy` and consider turning it into a `copyWith`.